### PR TITLE
feat: wrap use-case in transaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "repl": "pnpm run start --entryFile repl",
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { BooksModule } from './books/books.module';
 import { BorrowingModule } from './borrowing/borrowing.module';
 import { DevModule } from './dev/dev.module';
 import { UsersModule } from './users/users.module';
+import { ScopedTypeOrmModule } from './scoped-typeorm/scoped-typeorm.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { UsersModule } from './users/users.module';
       // Automatically create tables, great for development but very dangerous for production
       synchronize: true,
     }),
+    ScopedTypeOrmModule.forRoot(),
     AuthModule,
     BooksModule,
     BorrowingModule,

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,13 +1,17 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtModule } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Transaction } from '../transactions/transaction.model';
+import { Book } from '../books/book.model';
+import { Borrowing } from '../borrowing/borrowing.model';
 import { JWT_SECRET } from '../constants';
-import { UsersModule } from '../users/users.module';
+import { User } from '../users/user.model';
 import { AuthGuard } from './auth.guard';
 
 @Module({
   imports: [
-    UsersModule,
+    TypeOrmModule.forFeature([User, Book, Borrowing, Transaction]),
     JwtModule.register({
       secret: JWT_SECRET,
     }),

--- a/src/books/books.controller.ts
+++ b/src/books/books.controller.ts
@@ -15,10 +15,17 @@ import { UpdateBookDto } from './dto/update-book.dto';
 
 @Controller('books')
 export class BooksController {
+  private count: number = 0;
+
   constructor(private readonly booksService: BooksService) {}
 
   @Get()
   getBooks() {
+    // You can check that this controller acts as a static provider
+    // even though it's dependent upon a request-scoped, durable service
+    //
+    // If this controller were executed from within a transaction, it would _not_ be static
+    console.log(this.count++);
     return this.booksService.getBooks();
   }
 

--- a/src/books/books.module.ts
+++ b/src/books/books.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScopedTypeOrmModule } from '../scoped-typeorm/scoped-typeorm.module';
 import { Book } from './book.model';
 import { BooksController } from './books.controller';
 import { BooksService } from './books.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Book])],
+  imports: [ScopedTypeOrmModule.forFeature([Book])],
   controllers: [BooksController],
   providers: [BooksService],
   exports: [BooksService],

--- a/src/borrowing/borrowing.controller.ts
+++ b/src/borrowing/borrowing.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post } from '@nestjs/common';
 import { Admin } from '../auth/admin.decorator';
 import { ReqUser } from '../auth/user.decorator';
 import { User } from '../users/user.model';
@@ -6,6 +6,7 @@ import { BorrowingService } from './borrowing.service';
 import { BorrowBookDto } from './dto/borrow-book.dto';
 import { ReturnBookDto } from './dto/return-book.dto';
 import { ScopedController } from '../scoped-typeorm/scoped-controller';
+import { TestService } from './test.service';
 
 @Controller('borrow')
 export class BorrowingController extends ScopedController {
@@ -28,6 +29,14 @@ export class BorrowingController extends ScopedController {
   async scanOutstandingBooks() {
     return this.runInTransaction(async (resolver) =>
       (await resolver(BorrowingService)).scanOutstandingBooks(),
+    );
+  }
+
+  @Get('test')
+  async test() {
+    return this.runInTransaction(async (resolver) =>
+      // Using the REQUEST token still works as expected
+      (await resolver(TestService)).getIp(),
     );
   }
 }

--- a/src/borrowing/borrowing.controller.ts
+++ b/src/borrowing/borrowing.controller.ts
@@ -5,24 +5,29 @@ import { User } from '../users/user.model';
 import { BorrowingService } from './borrowing.service';
 import { BorrowBookDto } from './dto/borrow-book.dto';
 import { ReturnBookDto } from './dto/return-book.dto';
+import { ScopedController } from '../scoped-typeorm/scoped-controller';
 
 @Controller('borrow')
-export class BorrowingController {
-  constructor(private readonly borrowingService: BorrowingService) {}
-
+export class BorrowingController extends ScopedController {
   @Post()
-  borrowBook(@Body() { bookId }: BorrowBookDto, @ReqUser() user: User) {
-    return this.borrowingService.borrowBook(user.id, bookId);
+  async borrowBook(@Body() { bookId }: BorrowBookDto, @ReqUser() user: User) {
+    return this.runInTransaction(async (resolver) =>
+      (await resolver(BorrowingService)).borrowBook(user.id, bookId),
+    );
   }
 
   @Post('return')
-  returnBook(@Body() { bookId }: ReturnBookDto, @ReqUser() user: User) {
-    return this.borrowingService.returnBook(user.id, bookId);
+  async returnBook(@Body() { bookId }: ReturnBookDto, @ReqUser() user: User) {
+    return this.runInTransaction(async (resolver) =>
+      (await resolver(BorrowingService)).returnBook(user.id, bookId),
+    );
   }
 
   @Post('scan')
   @Admin()
-  scanOutstandingBooks() {
-    return this.borrowingService.scanOutstandingBooks();
+  async scanOutstandingBooks() {
+    return this.runInTransaction(async (resolver) =>
+      (await resolver(BorrowingService)).scanOutstandingBooks(),
+    );
   }
 }

--- a/src/borrowing/borrowing.module.ts
+++ b/src/borrowing/borrowing.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScopedTypeOrmModule } from '../scoped-typeorm/scoped-typeorm.module';
 import { Book } from '../books/book.model';
 import { BooksModule } from '../books/books.module';
 import { User } from '../users/user.model';
@@ -7,10 +7,11 @@ import { UsersModule } from '../users/users.module';
 import { BorrowingController } from './borrowing.controller';
 import { Borrowing } from './borrowing.model';
 import { BorrowingService } from './borrowing.service';
+import { Transaction } from '../transactions/transaction.model';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Borrowing, User, Book]),
+    ScopedTypeOrmModule.forFeature([Borrowing, User, Book, Transaction]),
     UsersModule,
     BooksModule,
   ],

--- a/src/borrowing/borrowing.module.ts
+++ b/src/borrowing/borrowing.module.ts
@@ -8,6 +8,7 @@ import { BorrowingController } from './borrowing.controller';
 import { Borrowing } from './borrowing.model';
 import { BorrowingService } from './borrowing.service';
 import { Transaction } from '../transactions/transaction.model';
+import { TestService } from './test.service';
 
 @Module({
   imports: [
@@ -16,6 +17,6 @@ import { Transaction } from '../transactions/transaction.model';
     BooksModule,
   ],
   controllers: [BorrowingController],
-  providers: [BorrowingService],
+  providers: [BorrowingService, TestService],
 })
 export class BorrowingModule {}

--- a/src/borrowing/test.service.ts
+++ b/src/borrowing/test.service.ts
@@ -1,0 +1,16 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { Request } from 'express';
+
+/**
+ * This service is just to demonstrate that we can still use the REQUEST token
+ * in our use-cases.
+ */
+@Injectable()
+export class TestService {
+  constructor(@Inject(REQUEST) private readonly request: Request) {}
+
+  getIp() {
+    return this.request.ip;
+  }
+}

--- a/src/dev/dev.controller.ts
+++ b/src/dev/dev.controller.ts
@@ -7,13 +7,9 @@ import { DevService } from './dev.service';
 export class DevController {
   constructor(private readonly devService: DevService) {}
 
-  @Post('reset')
-  reset() {
-    return this.devService.truncate();
-  }
-
   @Post('seed')
-  seed() {
+  async seed() {
+    await this.devService.truncate();
     return this.devService.seed();
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,12 @@
 import { ValidationPipe } from '@nestjs/common';
+import { ContextIdFactory } from '@nestjs/core';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ScopedContextIdStrategy } from './scoped-typeorm/context-id-strategy';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  ContextIdFactory.apply(new ScopedContextIdStrategy());
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -1,0 +1,7 @@
+import { repl } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  await repl(AppModule);
+}
+bootstrap();

--- a/src/scoped-typeorm/context-id-strategy.ts
+++ b/src/scoped-typeorm/context-id-strategy.ts
@@ -1,0 +1,16 @@
+import {
+  ContextId,
+  ContextIdFactory,
+  ContextIdStrategy,
+  HostComponentInfo,
+} from '@nestjs/core';
+
+export class ScopedContextIdStrategy implements ContextIdStrategy {
+  private staticContextId = ContextIdFactory.create();
+
+  attach(contextId: ContextId) {
+    return (info: HostComponentInfo) => {
+      return info.isTreeDurable ? this.staticContextId : contextId;
+    };
+  }
+}

--- a/src/scoped-typeorm/scoped-controller.ts
+++ b/src/scoped-typeorm/scoped-controller.ts
@@ -1,0 +1,36 @@
+import { Inject, Type } from '@nestjs/common';
+import { ContextIdFactory, ModuleRef } from '@nestjs/core';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+
+export type Resolver = <T>(token: Type<T> | string | symbol) => Promise<T>;
+
+export abstract class ScopedController {
+  @Inject(ModuleRef)
+  protected readonly moduleRef: ModuleRef;
+
+  @InjectDataSource()
+  protected readonly dataSource: DataSource;
+
+  protected async runInTransaction<R>(
+    fn: (resolve: Resolver) => Promise<R>,
+  ): Promise<R> {
+    const contextId = ContextIdFactory.create();
+    const queryRunner = this.dataSource.createQueryRunner();
+    this.moduleRef.registerRequestByContextId({ queryRunner }, contextId);
+    const resolver: Resolver = (token) =>
+      this.moduleRef.resolve(token, contextId);
+    await queryRunner.startTransaction();
+    let result: R;
+    try {
+      result = await fn(resolver);
+      await queryRunner.commitTransaction();
+    } catch (e) {
+      await queryRunner.rollbackTransaction();
+      throw e;
+    } finally {
+      await queryRunner.release();
+    }
+    return result;
+  }
+}

--- a/src/scoped-typeorm/scoped-typeorm.module.ts
+++ b/src/scoped-typeorm/scoped-typeorm.module.ts
@@ -1,21 +1,29 @@
-import { DynamicModule, Module, Provider } from '@nestjs/common';
-import { REQUEST } from '@nestjs/core';
+import { DynamicModule, Module, Provider, Scope } from '@nestjs/common';
 import { getDataSourceToken, getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource, QueryRunner } from 'typeorm';
-import { Request } from 'express';
-
-type ReqOrQueryRunner = { queryRunner: QueryRunner } | Request;
+import { transactionStorage } from './transaction-store';
+import { ScopedInterceptor } from './scoped.interceptor';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 
 @Module({})
 export class ScopedTypeOrmModule {
   static forFeature(entities: any[]): DynamicModule {
     const providers = entities.map(
       (entity): Provider => ({
+        // We override the TypeORM repository for backward compatibility with the Nest TypeOrmModule
         provide: getRepositoryToken(entity),
-        inject: [REQUEST, getDataSourceToken()],
-        useFactory: (ctx: ReqOrQueryRunner, dataSource: DataSource) => {
-          if (ctx && 'queryRunner' in ctx) {
-            return ctx.queryRunner.manager.getRepository(entity);
+        // This effectively makes the entire app request-scoped,
+        // it's required to dynamically resolve the repositories
+        scope: Scope.REQUEST,
+        // But the durable flag allows us to re-use repositories outside of transactions
+        // using the ScopedContextIdStrategy to cache them
+        durable: true,
+        inject: [getDataSourceToken()],
+        useFactory: (dataSource: DataSource) => {
+          const queryRunner: QueryRunner | undefined =
+            transactionStorage.getStore()?.queryRunner;
+          if (queryRunner) {
+            return queryRunner.manager.getRepository(entity);
           }
           return dataSource.getRepository(entity);
         },
@@ -25,6 +33,19 @@ export class ScopedTypeOrmModule {
       module: ScopedTypeOrmModule,
       providers: providers,
       exports: providers,
+    };
+  }
+
+  static forRoot(): DynamicModule {
+    return {
+      module: ScopedTypeOrmModule,
+      providers: [
+        ScopedInterceptor,
+        {
+          provide: APP_INTERCEPTOR,
+          useClass: ScopedInterceptor,
+        },
+      ],
     };
   }
 }

--- a/src/scoped-typeorm/scoped-typeorm.module.ts
+++ b/src/scoped-typeorm/scoped-typeorm.module.ts
@@ -1,0 +1,30 @@
+import { DynamicModule, Module, Provider } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { getDataSourceToken, getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource, QueryRunner } from 'typeorm';
+import { Request } from 'express';
+
+type ReqOrQueryRunner = { queryRunner: QueryRunner } | Request;
+
+@Module({})
+export class ScopedTypeOrmModule {
+  static forFeature(entities: any[]): DynamicModule {
+    const providers = entities.map(
+      (entity): Provider => ({
+        provide: getRepositoryToken(entity),
+        inject: [REQUEST, getDataSourceToken()],
+        useFactory: (ctx: ReqOrQueryRunner, dataSource: DataSource) => {
+          if (ctx && 'queryRunner' in ctx) {
+            return ctx.queryRunner.manager.getRepository(entity);
+          }
+          return dataSource.getRepository(entity);
+        },
+      }),
+    );
+    return {
+      module: ScopedTypeOrmModule,
+      providers: providers,
+      exports: providers,
+    };
+  }
+}

--- a/src/scoped-typeorm/scoped.interceptor.ts
+++ b/src/scoped-typeorm/scoped.interceptor.ts
@@ -1,0 +1,16 @@
+import { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common';
+import { transactionStorage } from './transaction-store';
+import { firstValueFrom, of } from 'rxjs';
+
+export class ScopedInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler) {
+    const request = context.switchToHttp().getRequest();
+
+    // Cache the request in the AsyncStorage, so we can make it available
+    // to our DI subtree later
+    return transactionStorage.run({ request }, async () => {
+      const result = await firstValueFrom(next.handle());
+      return of(result);
+    });
+  }
+}

--- a/src/scoped-typeorm/transaction-store.ts
+++ b/src/scoped-typeorm/transaction-store.ts
@@ -1,0 +1,9 @@
+import { Request } from 'express';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { QueryRunner } from 'typeorm';
+
+type TransactionStore = {
+  request: Request;
+  queryRunner?: QueryRunner;
+};
+export const transactionStorage = new AsyncLocalStorage<TransactionStore>();

--- a/src/transactions/transactions.module.ts
+++ b/src/transactions/transactions.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScopedTypeOrmModule } from '../scoped-typeorm/scoped-typeorm.module';
 import { Transaction } from './transaction.model';
 import { TransactionsService } from './transactions.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Transaction])],
+  imports: [ScopedTypeOrmModule.forFeature([Transaction])],
   providers: [TransactionsService],
   exports: [TransactionsService],
 })

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,12 +1,18 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { Book } from '../books/book.model';
+import { Borrowing } from '../borrowing/borrowing.model';
+import { Transaction } from '../transactions/transaction.model';
+import { ScopedTypeOrmModule } from '../scoped-typeorm/scoped-typeorm.module';
 import { TransactionsModule } from '../transactions/transactions.module';
 import { User } from './user.model';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), TransactionsModule],
+  imports: [
+    ScopedTypeOrmModule.forFeature([User, Transaction, Borrowing, Book]),
+    TransactionsModule,
+  ],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],

--- a/test/borrowing/borrow-book.e2e-spec.ts
+++ b/test/borrowing/borrow-book.e2e-spec.ts
@@ -20,7 +20,7 @@ describe('Borrow book (e2e)', () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
-    usersService = app.get(UsersService);
+    usersService = await app.resolve(UsersService);
     const devService: DevService = app.get(DevService);
     await devService.truncate();
     await devService.seed();

--- a/test/borrowing/return-book.e2e-spec.ts
+++ b/test/borrowing/return-book.e2e-spec.ts
@@ -19,7 +19,7 @@ describe('Return book (e2e)', () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
-    usersService = app.get(UsersService);
+    usersService = await app.resolve(UsersService);
     const devService: DevService = app.get(DevService);
     await devService.truncate();
     await devService.seed();
@@ -55,6 +55,7 @@ describe('Return book (e2e)', () => {
   });
 
   it('a user cannot return a book after it was marked lost', async () => {
+    const userBefore = await usersService.getUser(4);
     const response = await request(app.getHttpServer())
       .post('/borrow/return')
       .send({
@@ -62,5 +63,7 @@ describe('Return book (e2e)', () => {
       })
       .set('Authorization', `Bearer ${suspendedUserToken}`);
     expect(response.status).toEqual(400);
+    const userAfter = await usersService.getUser(4);
+    expect(userBefore.credit).toEqual(userAfter.credit);
   });
 });


### PR DESCRIPTION
If you want to review by commit, you can watch the POC build up:

1. Makes the TypeORM repositories request-scoped, using either the transaction-scoped queryRunner, or the root dataSource. This allows us to wrap a use-case in a transaction at the controller-level.
2. Optimize the strategy by caching repositories that are not transaction-scoped, by leveraging [durable providers](https://docs.nestjs.com/fundamentals/injection-scopes#durable-providers).